### PR TITLE
Document that exec, attach and portforward must be explicitly set 

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ API calls can be logged repeatedly due to Kubernetes repeatedly re-calling the [
 
 WARNING: This can only log mutation/creation requests. Read Only requests are *not* sent to mutating or validating webhooks unfortunately.
 
+WARNING: "pods/exec", "pods/attach", "pods/portforward" must be explicitly listed as a rule for them to be recorded, due to <https://github.com/kubernetes/kubernetes/issues/115523>
+
 
 ### Certificate expires/invalid
 

--- a/k8s/webhook.yaml
+++ b/k8s/webhook.yaml
@@ -22,4 +22,9 @@ webhooks:
         apiVersions: ["*"]
         resources: ["*"]
         scope: "*"
+      # Required due to https://github.com/kubernetes/kubernetes/issues/115523
+      - apiGroups: ["*"]
+        apiVersions: ["*"]
+        operations: ["*"]
+        resources: ["pods/exec", "pods/attach", "pods/portforward"]      
     admissionReviewVersions: ["v1"]


### PR DESCRIPTION
due to upstream bug