### PR TITLE
Fix the log level

### DIFF
--- a/internal/common/logger.go
+++ b/internal/common/logger.go
@@ -16,9 +16,9 @@ const (
 	Prod
 )
 
-var Logger *zap.SugaredLogger = ConfigGlobalLogger(Dbg)
+var Logger *zap.SugaredLogger = NewLogger(Dbg)
 
-func ConfigGlobalLogger(cfg LogCfg) *zap.SugaredLogger {
+func NewLogger(cfg LogCfg) *zap.SugaredLogger {
 	var logger *zap.Logger
 	var err error
 
@@ -36,4 +36,8 @@ func ConfigGlobalLogger(cfg LogCfg) *zap.SugaredLogger {
 	}
 
 	return logger.Sugar()
+}
+
+func ConfigGlobalLogger(cfg LogCfg) {
+	Logger = NewLogger(cfg)
 }

--- a/internal/common/logger_test.go
+++ b/internal/common/logger_test.go
@@ -1,0 +1,26 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/RichardoC/kube-audit-rest/internal/common"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestConfigGlobalLogger(t *testing.T) {
+	testCases := []struct {
+		name          string
+		desiredLevel  common.LogCfg
+		expectedLevel zapcore.Level
+	}{
+		{"dbg", common.Dbg, zapcore.DebugLevel},
+		{"prod", common.Prod, zapcore.InfoLevel},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			common.ConfigGlobalLogger(tc.desiredLevel)
+			assert.Equal(t, common.Logger.Level(), tc.expectedLevel)
+		})
+	}
+}


### PR DESCRIPTION
The way to configure the common logger had a bug that caused the logger to run always on debug level. This commit fixes that and adds a test to avoid repeating this bug in the future.