### PR TITLE
Fix regression - standard library logs now sent to structured logger

### DIFF
--- a/cmd/kube-audit-rest/main.go
+++ b/cmd/kube-audit-rest/main.go
@@ -60,7 +60,6 @@ func main() {
 	}
 	defer common.Logger.Sync()
 
-
 	common.Logger.Infow("Got config", "config", opts)
 
 	// Set maxprocs and have it use our nice logger

--- a/cmd/kube-audit-rest/main.go
+++ b/cmd/kube-audit-rest/main.go
@@ -60,6 +60,7 @@ func main() {
 	}
 	defer common.Logger.Sync()
 
+
 	common.Logger.Infow("Got config", "config", opts)
 
 	// Set maxprocs and have it use our nice logger

--- a/internal/common/logger.go
+++ b/internal/common/logger.go
@@ -40,4 +40,7 @@ func NewLogger(cfg LogCfg) *zap.SugaredLogger {
 
 func ConfigGlobalLogger(cfg LogCfg) {
 	Logger = NewLogger(cfg)
+	// Send standard logging to zap
+	// ignoring undo as we don't want to undo this
+	_ = zap.RedirectStdLog(Logger.Desugar())
 }

--- a/testing/locally/main.go
+++ b/testing/locally/main.go
@@ -46,6 +46,26 @@ func main() {
 
 	testFailureCount := 0
 
+	// send a request which doesn't trust our CA
+	// Set up custom http client so we can correctly validate TLS
+	clientFaulty := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if addr == fmt.Sprintf("kube-audit-rest:%d", opts.ServerPort) {
+					addr = fmt.Sprintf("127.0.0.1:%d", opts.ServerPort)
+				}
+				dialer := &net.Dialer{}
+				return dialer.DialContext(ctx, network, addr)
+			},
+		},
+	}
+	_, err = clientFaulty.Post((fmt.Sprintf("https://kube-audit-rest:%d/log-request", opts.ServerPort)), "application/json", bytes.NewReader([]byte("abc")))
+
+	if !strings.Contains(err.Error(), "failed to verify certificate") {
+		log.Println("error: didn't fail when go doesn't trust the CA.")
+		testFailureCount++
+	}
+
 	// Set up for TLS
 	caCert, err := ioutil.ReadFile("tmp/rootCA.pem")
 	if err != nil {


### PR DESCRIPTION
This means certificate errors get sent to the structured logger

Without this, the logs look like the following

```
{"level":"info","ts":1689851326.4659414,"caller":"prometheus_metrics/prometheus_metrics.go:46","msg":"Starting server","addr":":55555"}
{"level":"info","ts":1689851326.4664195,"caller":"log_request_listener/log_request_listener.go:41","msg":"Starting server","addr":":9090"}
2023/07/20 11:08:51 http: TLS handshake error from 172.16.0.6:49206: remote error: tls: bad certificate
2023/07/20 11:08:58 http: TLS handshake error from 172.16.0.4:50392: remote error: tls: bad certificate
```