### PR TITLE
Fix full elastic stack example

### DIFF
--- a/examples/full-elastic-stack/certs/certs.sh
+++ b/examples/full-elastic-stack/certs/certs.sh
@@ -4,20 +4,19 @@ set -eux
 
 # Default to root if no .git missing
 ROOT=$(git rev-parse --show-toplevel || echo '.' )
+cd "$ROOT"
 
-cd $ROOT
+CONF_DIR="$(pwd)/examples/full-elastic-stack/certs"
 
-CONF_DIR=$(pwd)/examples/full-elastic-stack/certs
-
-TMP=$(pwd)/tmp/full-elastic-stack
-echo $TMP
-mkdir -p $TMP
-cd $TMP
+TMP="$(pwd)/tmp/full-elastic-stack"
+echo "$TMP"
+mkdir -p "$TMP"
+cd "$TMP"
 
 openssl genrsa -out rootCA.key 2048 &> /dev/null
 
-openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1460 -out rootCA.pem -config $CONF_DIR/ca.cnf &> /dev/null
+openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1460 -out rootCA.pem -config "$CONF_DIR/ca.cnf" &> /dev/null
 
-openssl req -new -nodes -sha256 -out server.csr -newkey rsa:2048 -keyout server.key -config $CONF_DIR/server.csr.cnf &> /dev/null
+openssl req -new -nodes -sha256 -out server.csr -newkey rsa:2048 -keyout server.key -config "$CONF_DIR/server.csr.cnf" &> /dev/null
 
-openssl x509 -req -in server.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out server.crt -days 500 -sha256 -extensions v3_req -extfile $CONF_DIR/server.csr.cnf &> /dev/null
+openssl x509 -req -in server.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out server.crt -days 500 -sha256 -extensions v3_req -extfile "$CONF_DIR/server.csr.cnf" &> /dev/null

--- a/examples/full-elastic-stack/k8s/kube-audit-rest.yaml
+++ b/examples/full-elastic-stack/k8s/kube-audit-rest.yaml
@@ -127,6 +127,13 @@ spec:
             - ALL 
       - name: vector
         image: docker.io/timberio/vector:0.33.0-distroless-static@sha256:90e14483720ea7dfa5c39812a30f37d3bf3a94b6611787a0d14055b8ac31eb1f
+        resources:
+          requests:
+            cpu:  "2m"
+            memory: "10Mi"
+          limits:
+            cpu: "2"
+            memory: "512Mi"
         env:
         - name: ESP
           valueFrom:


### PR DESCRIPTION
* Fixed certs.sh to work anywhere by surrounding the paths with ""
* Fixed default max_depth in vector configuration to 2 to prevent issues due to inconsistent data when publishing to Elasticsearch
* added resource limits to the vector pod, as VS Code suggested to fix that