### PR TITLE
chore: remove unused arch from amd64 build on PRs

### DIFF
--- a/.github/workflows/testing-PRs.yml
+++ b/.github/workflows/testing-PRs.yml
@@ -71,7 +71,7 @@ jobs:
           tags: |
             ghcr.io/richardoc/kube-audit-rest:test-distroless
             ghcr.io/richardoc/kube-audit-rest:latest
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
   execute-unittests:


### PR DESCRIPTION
Just for PR testing, we use separate workers for the AMD64 and AARCH64 containers to speed up review.
Currently we're trying to build AMD64 containers on a misconfigured AARCH64 worker, which we don't need as we already builg it on the native AMD64 workers.