### PR TITLE
fix: adding new flag for stdout formatting

### DIFF
--- a/cmd/kube-audit-rest/main.go
+++ b/cmd/kube-audit-rest/main.go
@@ -41,6 +41,7 @@ type Options struct {
 	ServerPort       int    `long:"server-port" description:"Port to run https server on" default:"9090"`
 	MetricsPort      int    `long:"metrics-port" description:"Port to run http metrics server on" default:"55555"`
 	Verbose          bool   `long:"verbosity" short:"v" description:"Uses zap Development default verbose mode rather than production"`
+	LoggingFormat    string `long:"logging-format" description:"Output format for stderr/stdout. Only works when audit-to-std-log is used. One of: (json, console)" default:"json"`
 }
 
 func main() {
@@ -69,7 +70,7 @@ func main() {
 	metricsServer := prometheusmetrics.New(opts.MetricsPort)
 	var auditWriter auditwritter.AuditWritter
 	if opts.AuditToStdErr {
-		auditWriter = stderrwriter.New()
+		auditWriter = stderrwriter.New(opts.LoggingFormat)
 	} else {
 		auditWriter = diskwriter.New(opts.LoggerFilename, opts.LoggerMaxSize, opts.LoggerMaxBackups)
 	}

--- a/cmd/kube-audit-rest/main.go
+++ b/cmd/kube-audit-rest/main.go
@@ -41,7 +41,7 @@ type Options struct {
 	ServerPort       int    `long:"server-port" description:"Port to run https server on" default:"9090"`
 	MetricsPort      int    `long:"metrics-port" description:"Port to run http metrics server on" default:"55555"`
 	Verbose          bool   `long:"verbosity" short:"v" description:"Uses zap Development default verbose mode rather than production"`
-	LoggingFormat    string `long:"logging-format" description:"Output format for stderr/stdout. Only works when audit-to-std-log is used. One of: (json, console)" default:"json"`
+	LoggingFormat    string `long:"logging-format" description:"Output format for stderr/stdout when --audit-to-std-log is used. One of: (json, console)" default:"json"`
 }
 
 func main() {

--- a/internal/audit_writer/stderr_writer/stderr_writer.go
+++ b/internal/audit_writer/stderr_writer/stderr_writer.go
@@ -6,6 +6,7 @@ import (
 	auditwritter "github.com/RichardoC/kube-audit-rest/internal/audit_writer"
 	commonwriter "github.com/RichardoC/kube-audit-rest/internal/audit_writer/common_writer"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zapio"
 )
 
@@ -16,6 +17,7 @@ type stderrWritter struct {
 func New() auditwritter.AuditWritter {
 	zapConfig := zap.NewProductionConfig()
 	zapConfig.Encoding = "console"
+	zapConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	lg, err := zapConfig.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)

--- a/internal/audit_writer/stderr_writer/stderr_writer.go
+++ b/internal/audit_writer/stderr_writer/stderr_writer.go
@@ -14,18 +14,8 @@ type stderrWritter struct {
 }
 
 func New() auditwritter.AuditWritter {
-	zapConfig := zap.Config{
-		Level:       zap.NewAtomicLevelAt(zap.InfoLevel),
-		Development: false,
-		Sampling: &zap.SamplingConfig{
-			Initial:    100,
-			Thereafter: 100,
-		},
-		Encoding:         "console",
-		EncoderConfig:    zap.NewProductionEncoderConfig(),
-		OutputPaths:      []string{"stderr"},
-		ErrorOutputPaths: []string{"stderr"},
-	}
+	zapConfig := zap.NewProductionConfig()
+	zapConfig.Encoding = "console"
 	lg, err := zapConfig.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)

--- a/internal/audit_writer/stderr_writer/stderr_writer.go
+++ b/internal/audit_writer/stderr_writer/stderr_writer.go
@@ -6,7 +6,6 @@ import (
 	auditwritter "github.com/RichardoC/kube-audit-rest/internal/audit_writer"
 	commonwriter "github.com/RichardoC/kube-audit-rest/internal/audit_writer/common_writer"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zapio"
 )
 
@@ -14,10 +13,9 @@ type stderrWritter struct {
 	writer *zapio.Writer
 }
 
-func New() auditwritter.AuditWritter {
+func New(loggingFormat string) auditwritter.AuditWritter {
 	zapConfig := zap.NewProductionConfig()
-	zapConfig.Encoding = "console"
-	zapConfig.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	zapConfig.Encoding = loggingFormat
 	lg, err := zapConfig.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)

--- a/internal/audit_writer/stderr_writer/stderr_writer.go
+++ b/internal/audit_writer/stderr_writer/stderr_writer.go
@@ -14,7 +14,19 @@ type stderrWritter struct {
 }
 
 func New() auditwritter.AuditWritter {
-	lg, err := zap.NewProduction()
+	zapConfig := zap.Config{
+		Level:       zap.NewAtomicLevelAt(zap.InfoLevel),
+		Development: false,
+		Sampling: &zap.SamplingConfig{
+			Initial:    100,
+			Thereafter: 100,
+		},
+		Encoding:         "console",
+		EncoderConfig:    zap.NewProductionEncoderConfig(),
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+	}
+	lg, err := zapConfig.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}

--- a/internal/audit_writer/stderr_writer/stderr_writer_test.go
+++ b/internal/audit_writer/stderr_writer/stderr_writer_test.go
@@ -6,8 +6,14 @@ import (
 	stderrwriter "github.com/RichardoC/kube-audit-rest/internal/audit_writer/stderr_writer"
 )
 
-func Test_WhenWritingEvent_ThenSucceeds(t *testing.T) {
-	writer := stderrwriter.New()
+func Test_WhenWritingEventWithJsonFormat_ThenSucceeds(t *testing.T) {
+	writer := stderrwriter.New("json")
+	event := "{\"testEvent\": \"test\"}"
+	writer.LogEvent([]byte(event))
+}
+
+func Test_WhenWritingEventWithConsoleFormat_ThenSucceeds(t *testing.T) {
+	writer := stderrwriter.New("console")
 	event := "{\"testEvent\": \"test\"}"
 	writer.LogEvent([]byte(event))
 }


### PR DESCRIPTION
Hiya peeps!

Firstly, I would like to highlight how useful this project is! Thank you for maintaining it!

During the implementation of this logger in our EKS systems, we have noticed that when we output the audit logs to stdout instead of the file, the logs are a bit hard to read due to the backslashes(`\`). We use Grafana, and it is also the same over there as one would expect.

When run test on `internal/audit_writer/stderr_writer/stderr_writer_test.go`, it also displays it like this:
```
{"level":"info","ts":1755282421.2077508,"caller":"zapio/writer.go:146","msg":"{\"testEvent\":\"test\",\"requestReceivedTimestamp\":\"2025-08-15T20:27:01.205847+02:00\"}"}
```

With this PR,  a new command argument is being passed so that the log formatting can be altered through it. I have also updated the test for this:
```
1.7552824771270652e+09  info    zapio/writer.go:146     {"testEvent":"test","requestReceivedTimestamp":"2025-08-15T20:27:57.125345+02:00"}
```

I agree having this in json format is ideal if the data needs to be processed additionally, however the `console` output works fine too and integrates well with Grafana as well. 

**Result**

with --logging-format=json(or undefined):
```
{"level":"info","ts":1755275482.2532275,"caller":"zapio/writer.go:146","msg":"{\"kind\":\"AdmissionReview\",\"apiVersion\":\"admission.k8s.io/v1\",\"request\":{\"uid\":\"ec82-4647-bca8-4aa993a6242a\",\"kind\":{\"group\":\"\",\"version\":\"v1\",\"kind\":\"Secret\"},\"resource\":{\"group\":\"\",\"version\":\"v1\",\"resource\":\"secrets\"},\"requestKind\":{\"group\":\"\",\"version\":\"v1\",\"kind\":\"Secret\"},\"requestResource\":
```
with --logging-format=console:
```
2025-08-15T19:21:20.895Z	info	zapio/writer.go:146	{"kind":"AdmissionReview","apiVersion":"admission.k8s.io/v1","request":{"uid":"3eeb-45ff-853b-fb4cd966bef6","kind":{"group":"","version":"v1","kind":"Secret"},"resource":{"group":"","version":"v1","resource":"secrets"},"requestKind":{"group":"","version":"v1","kind":"Secret"}
```

Please let me know if there is anything I can add to improve this PR