### PR TITLE
Helm chart for kube-audit-rest w/ fluent-bit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp/*
-kube-audit-rest
+/kube-audit-rest
+/cmd/kube-audit-rest/kube-audit-rest
 .DS_Store

--- a/charts/kube-audit-rest/.helmignore
+++ b/charts/kube-audit-rest/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kube-audit-rest/Chart.yaml
+++ b/charts/kube-audit-rest/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kube-audit-rest
+description: Helm chart for kube-audit-rest
+type: application
+version: 0.1.0
+appVersion: "1.0.22"

--- a/charts/kube-audit-rest/templates/_helpers.tpl
+++ b/charts/kube-audit-rest/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kube-audit-rest.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kube-audit-rest.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kube-audit-rest.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kube-audit-rest.labels" -}}
+helm.sh/chart: {{ include "kube-audit-rest.chart" . }}
+{{ include "kube-audit-rest.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kube-audit-rest.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kube-audit-rest.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kube-audit-rest.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kube-audit-rest.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image tag
+*/}}
+{{- define "kube-audit-rest.imageTag" -}}
+{{- $tag := printf "%s-distroless" .Chart.AppVersion }}
+{{- default $tag .Values.image.tag }}
+{{- end }}
+
+{{/*
+Compute hash of configuration
+(checksum change should trigger deployment restart)
+*/}}
+{{- define "kube-audit-rest.configHash" -}}
+{{- cat .Values.fluentBit.config .Values.fluentBit.configLua | sha256sum }}
+{{- end }}

--- a/charts/kube-audit-rest/templates/deployment.yaml
+++ b/charts/kube-audit-rest/templates/deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kube-audit-rest.fullname" . }}
+  labels:
+    {{- include "kube-audit-rest.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kube-audit-rest.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        config-hash: {{ include "kube-audit-rest.configHash" . }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kube-audit-rest.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kube-audit-rest.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: kube-audit-rest
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ include "kube-audit-rest.imageTag" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 9090
+              protocol: TCP
+              name: https
+            - containerPort: 55555
+              protocol: TCP
+              name: metrics
+          {{- with .Values.options }}
+          command:
+            - "/kube-audit-rest"
+            {{- range $key, $val := . }}
+            - "--{{ $key }}={{ $val }}"
+            {{- end }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: logs
+              mountPath: "/tmp"
+            - mountPath: /etc/tls
+              name: cert
+              readOnly: true
+        - name: fluent-bit
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.fluentBit.image.repository }}:{{ .Values.fluentBit.image.tag }}"
+          imagePullPolicy: {{ .Values.fluentBit.image.pullPolicy }}
+          args: ["-c", "/cfg/fluent-bit.yaml"]
+          {{- with .Values.fluentBit.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: logs
+              mountPath: "/tmp"
+            - name: config
+              mountPath: "/cfg"
+              readOnly: true
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 422
+            secretName: {{ include "kube-audit-rest.fullname" . }}-cert
+        - name: logs
+          {{- toYaml .Values.logsVolume | nindent 10 }}
+        - name: config
+          secret:
+            secretName: {{ include "kube-audit-rest.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kube-audit-rest/templates/secret.yaml
+++ b/charts/kube-audit-rest/templates/secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kube-audit-rest.fullname" . }}
+  labels:
+    {{- include "kube-audit-rest.labels" . | nindent 4 }}
+stringData:
+  fluent-bit.yaml: |
+    {{- toYaml .Values.fluentBit.config | nindent 4 }}
+  fluent-bit.lua: |
+    {{ .Values.fluentBit.configLua | nindent 4 }}

--- a/charts/kube-audit-rest/templates/selfsigned-issuer.yaml
+++ b/charts/kube-audit-rest/templates/selfsigned-issuer.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "kube-audit-rest.fullname" . }}-selfsigned-issuer
+  labels:
+    {{- include "kube-audit-rest.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}

--- a/charts/kube-audit-rest/templates/service.yaml
+++ b/charts/kube-audit-rest/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kube-audit-rest.fullname" . }}
+  labels:
+    {{- include "kube-audit-rest.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    - port: 55555 # TODO
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "kube-audit-rest.selectorLabels" . | nindent 4 }}

--- a/charts/kube-audit-rest/templates/serviceaccount.yaml
+++ b/charts/kube-audit-rest/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kube-audit-rest.serviceAccountName" . }}
+  labels:
+    {{- include "kube-audit-rest.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/kube-audit-rest/templates/serving-cert.yaml
+++ b/charts/kube-audit-rest/templates/serving-cert.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "kube-audit-rest.fullname" . }}-cert
+  labels:
+    {{- include "kube-audit-rest.labels" . | nindent 4 }}
+spec:
+  dnsNames:
+    - "{{ include "kube-audit-rest.fullname" . }}.{{ .Release.Namespace }}.svc"
+    - "{{ include "kube-audit-rest.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain }}"
+  issuerRef:
+    kind: Issuer
+    name: {{ include "kube-audit-rest.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "kube-audit-rest.fullname" . }}-cert

--- a/charts/kube-audit-rest/templates/webhook.yaml
+++ b/charts/kube-audit-rest/templates/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "kube-audit-rest.fullname" . }}
+  annotations:
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "kube-audit-rest.fullname" . }}-cert"
+  labels:
+    {{- include "kube-audit-rest.labels" . | nindent 4 }}
+webhooks:
+  - name: "{{ include "kube-audit-rest.fullname" . }}.{{ .Release.Namespace }}.svc"
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: "{{ include "kube-audit-rest.fullname" . }}"
+        namespace: "{{ .Release.Namespace }}"
+        path: "/log-request"
+        port: {{ .Values.service.port }}
+    rules:
+      - operations: [ "*" ]
+        apiGroups: ["*"]
+        apiVersions: ["*"]
+        resources: ["*/*"]
+        scope: "*"
+    failurePolicy: Ignore
+    sideEffects: None
+    timeoutSeconds: 1

--- a/charts/kube-audit-rest/values.yaml
+++ b/charts/kube-audit-rest/values.yaml
@@ -1,0 +1,191 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/richardoc/kube-audit-rest
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is based on the chart appVersion
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+# kube-audit-rest command line options without '--' prefix
+options:
+  logger-max-size: 100
+
+podAnnotations: {}
+podLabels: {}
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 443
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /metrics
+    port: metrics
+
+readinessProbe:
+  httpGet:
+    path: /metrics
+    port: metrics
+
+logsVolume:
+  emptyDir:
+    sizeLimit: 1Gi
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+fluentBit:
+  image:
+    repository: cr.fluentbit.io/fluent/fluent-bit
+    pullPolicy: IfNotPresent
+    tag: 4.0.8
+
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  # fluent-bit configuration in a new YAML format
+  config:
+    parsers:
+      - name: admissionReview
+        format: json
+        time_key: requestReceivedTimestamp
+        time_format: "%Y-%m-%dT%H:%M:%S.%L"
+        time_keep: false
+    pipeline:
+      inputs:
+        - name: tail
+          path: /tmp/*.log
+          parser: admissionReview
+          refresh_interval: 30
+          buffer_max_size: 2M
+          skip_long_lines: "on"
+      filters:
+        - name: lua
+          match: '*'
+          script: /cfg/fluent-bit.lua
+          call: filter_message
+      outputs:
+        - name: stdout
+          match: '*'
+
+  # Lua code used to filter messages
+  configLua: |
+    -- Keys which might contain sensitive content
+    local function is_sensitive_key(key)
+        local lower_key = string.lower(tostring(key))
+
+        return string.find(lower_key, "password") or
+               string.find(lower_key, "passwd") or
+               string.find(lower_key, "pswd") or
+               string.find(lower_key, "secret") or
+               string.find(lower_key, "private") or
+               string.find(lower_key, "security_key") or
+               string.find(lower_key, "securitykey") or
+               string.find(lower_key, "private_key") or
+               string.find(lower_key, "privatekey") or
+               string.find(lower_key, "api_key") or
+               string.find(lower_key, "apikey") or
+               lower_key == "kubectl.kubernetes.io/last-applied-configuration"
+    end
+
+    -- Recursively walk through data structure and remove
+    -- values for potentially sensitive keys
+    local function redact_structure(data)
+        for k, v in pairs(data) do
+            if is_sensitive_key(k) then
+                data[k] = "***"
+            elseif type(v) == "table" then
+                data[k] = redact_structure(data[k])
+            end
+        end
+
+        return data
+    end
+
+    function filter_message(tag, timestamp, record)
+        if not record["request"] then
+            return 0, timestamp, record
+        end
+
+        -- drop some noisy messages
+        if record["request"]["kind"] and
+           (record["request"]["kind"]["group"] == "coordination.k8s.io" or
+            record["request"]["kind"]["kind"]  == "TokenReview")
+        then
+            return -1, timestamp, record
+        end
+
+        if record["request"]["object"] then
+            -- don't log any Secret data
+            if record["request"]["requestKind"] and record["request"]["requestKind"]["kind"] == "Secret" then
+                record["request"]["object"]["data"] = "***"
+            end
+
+            if record["request"]["object"]["metadata"] then
+                record["request"]["object"]["metadata"]["managedFields"] = nil
+            end
+        end
+
+        if record["request"]["oldObject"] then
+            -- don't log any Secret data
+            if record["request"]["requestKind"] and record["request"]["requestKind"]["kind"] == "Secret" then
+                record["request"]["oldObject"]["data"] = "***"
+            end
+
+            if record["request"]["oldObject"]["metadata"] then
+                record["request"]["oldObject"]["metadata"]["managedFields"] = nil
+            end
+        end
+
+        record = redact_structure(record)
+
+        return 1, timestamp, record
+    end


### PR DESCRIPTION
I have followed the examples from https://github.com/RichardoC/kube-audit-rest/tree/main/examples and prepared a Helm chart to easily deploy the kube-audit-rest. It's using fluent-bit (which is a tool we prefer in our env.) instead of vector and by default only outputs to stdout, the real output target needs to be configured for each environment. We are already using this chart for some time. 

If interested, Helm chart could be improved later to support different tools, or at least be able to disable fluent-bit and specify a completely custom sidecar container.

Minimal Helm values to get it working with e.g. Loki is:

```
fluentBit:
  config:
    pipeline:
      outputs:
        - name: loki
          match: '*'
          host: 'dummy'
          port: 'dummy'
          tenant_id: 'dummy'
          labels: 'job=kube-audit-rest'
          retry_limit: 3
          storage.total_limit_size: 8M
```

https://docs.fluentbit.io/manual/data-pipeline/outputs

Happy to discuss this.

One more thing -- thank you for creating and maintaining the kube-audit-rest!